### PR TITLE
Fjerner ugyldig spec.team fra workflow

### DIFF
--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -8,7 +8,6 @@ metadata:
     team: personbruker
 spec:
   image: {{ image }}
-  team: personbruker
   port: 3123
   liveness:
     path: /prototype/internal/isAlive


### PR DESCRIPTION
Fjerner ugyldig spec.team-nøkkel etter at strengere validering i nais trådte i kraft.